### PR TITLE
Fixes error when not subscribing to lookups

### DIFF
--- a/sms_server.js
+++ b/sms_server.js
@@ -68,7 +68,9 @@ Accounts.sms.sendVerificationCode = function (phone) {
   if (!Accounts.sms.client) throw new Meteor.Error('accounts-sms has not been configured');
 
   var lookup = Accounts.sms.client.lookup(phone);
-  if (lookup.carrier.type !== 'mobile') throw new Meteor.Error('not a mobile number');
+  if (lookup.carrier && lookup.carrier.type !== 'mobile') {
+    throw new Meteor.Error('not a mobile number');
+  }
 
   var code = Math.floor(Random.fraction() * 10000) + '';
 


### PR DESCRIPTION
If you don’t subscribe to Twilio’s premium lookups the package will throw even if it’s a mobile number.  

‘Cannot read the type of null’
